### PR TITLE
fix(storybook): ensure default Label styles are applied in stories

### DIFF
--- a/frontend/src/ui/label/Label.stories.js
+++ b/frontend/src/ui/label/Label.stories.js
@@ -12,13 +12,13 @@ export default {
 
 export const Required = () => (
   <Label htmlFor="file" required>
-    Label
+    <Label.Title>Label</Label.Title>
   </Label>
 );
 
 export const NotRequired = () => (
   <Label htmlFor="file">
-    Label
+    <Label.Title>Label</Label.Title>
   </Label>
 );
 


### PR DESCRIPTION
Updated Label.stories.js to wrap label text with <Label.Title> ensuring the default styles (typography and color) are correctly applied in Storybook previews.